### PR TITLE
Fix build issues

### DIFF
--- a/EyeTrackVRResonite/EyeTrackVR.cs
+++ b/EyeTrackVRResonite/EyeTrackVR.cs
@@ -147,7 +147,7 @@ namespace EyeTrackVRResonite
 
             public void RegisterInputs(InputInterface inputInterface)
             {
-                _eyes = new Eyes(inputInterface, "EyeTrackVR Tracking");
+                _eyes = new Eyes(inputInterface, "EyeTrackVR Tracking", true);
             }
 
             public void UpdateInputs(float deltaTime)

--- a/EyeTrackVRResonite/EyeTrackVRResonite.csproj
+++ b/EyeTrackVRResonite/EyeTrackVRResonite.csproj
@@ -6,7 +6,7 @@
         <OutputType>Library</OutputType>
         <AppDesignerFolder>Properties</AppDesignerFolder>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
         <FileAlignment>512</FileAlignment>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
It would seem that ResoniteModLoader switched to `net472` for its target framework, update EyeTrackVRResonite.csproj to correct the conflict.

Add the missing third parameter for `Eyes()` (supports pupil dilation). Not sure whether it should be true or false, but I successfully built a working mod with it set to true.